### PR TITLE
Add logLevel and fix RabbitMQ external secret

### DIFF
--- a/charts/osie/Chart.yaml
+++ b/charts/osie/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 25.5.0
+version: 25.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/osie/templates/_helpers.tpl
+++ b/charts/osie/templates/_helpers.tpl
@@ -247,7 +247,7 @@ Return the RabbitMQ secret key
         {{- "rabbitmq-password" }}
     {{- end }}
 {{- else -}}
-{{- "rabbitmq-password" }}
+    {{- "rabbitmq-password" }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/osie/templates/_helpers.tpl
+++ b/charts/osie/templates/_helpers.tpl
@@ -241,7 +241,7 @@ Return the RabbitMQ secret key
 */}}
 {{- define "osie.rabbitmq.secretPasswordKey" -}}
 {{- if .Values.externalRabbitmq.existingSecret -}}
-    {{- if .Values.rabbitmq.existingSecretPasswordKey }}
+    {{- if .Values.externalRabbitmq.existingSecretPasswordKey }}
         {{- printf "%s" .Values.externalRabbitmq.existingSecretPasswordKey -}}
     {{- else }}
         {{- "rabbitmq-password" }}

--- a/charts/osie/templates/_helpers.tpl
+++ b/charts/osie/templates/_helpers.tpl
@@ -241,7 +241,7 @@ Return the RabbitMQ secret key
 */}}
 {{- define "osie.rabbitmq.secretPasswordKey" -}}
 {{- if .Values.externalRabbitmq.existingSecret -}}
-    {{- printf "%s" .Values.externalRabbitmq.existingSecret -}}
+    {{- printf "%s" .Values.externalRabbitmq.existingSecretPasswordKey -}}
 {{- else if .Values.rabbitmq.enabled }}
     {{- printf "%s" (include "osie.rabbitmq.fullname" .) -}}
 {{- else -}}

--- a/charts/osie/templates/_helpers.tpl
+++ b/charts/osie/templates/_helpers.tpl
@@ -241,11 +241,13 @@ Return the RabbitMQ secret key
 */}}
 {{- define "osie.rabbitmq.secretPasswordKey" -}}
 {{- if .Values.externalRabbitmq.existingSecret -}}
-    {{- printf "%s" .Values.externalRabbitmq.existingSecretPasswordKey -}}
-{{- else if .Values.rabbitmq.enabled }}
-    {{- printf "%s" (include "osie.rabbitmq.fullname" .) -}}
+    {{- if .Values.rabbitmq.auth.existingSecretPasswordKey }}
+        {{- printf "%s" .Values.externalRabbitmq.existingSecretPasswordKey -}}
+    {{- else }}
+        {{- "rabbitmq-password" }}
+    {{- end }}
 {{- else -}}
-    {{- printf "%s-%s" (include "common.names.fullname" .) "externalrabbitmq" -}}
+{{- "rabbitmq-password" }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/osie/templates/_helpers.tpl
+++ b/charts/osie/templates/_helpers.tpl
@@ -241,7 +241,7 @@ Return the RabbitMQ secret key
 */}}
 {{- define "osie.rabbitmq.secretPasswordKey" -}}
 {{- if .Values.externalRabbitmq.existingSecret -}}
-    {{- if .Values.rabbitmq.auth.existingSecretPasswordKey }}
+    {{- if .Values.rabbitmq.existingSecretPasswordKey }}
         {{- printf "%s" .Values.externalRabbitmq.existingSecretPasswordKey -}}
     {{- else }}
         {{- "rabbitmq-password" }}

--- a/charts/osie/templates/osie-api/api-properties-configmap.yaml
+++ b/charts/osie/templates/osie-api/api-properties-configmap.yaml
@@ -13,7 +13,7 @@ data:
   application.yml: |
     logging:
       level:
-        root: INFO
+        root: {{ .Values.api.logLevel }}
     osie:
       license:
         key: {{ .Values.license.key }}

--- a/charts/osie/templates/osie-api/api-statefulset.yaml
+++ b/charts/osie/templates/osie-api/api-statefulset.yaml
@@ -40,7 +40,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "osie.rabbitmq.secretName" $apiContext }}
-                  key: "rabbitmq-password"
+                  key: {{ include "osie.rabbitmq.secretPasswordKey" $apiContext }}
             {{- if (eq .Values.encryption.provider "bcrypt") }}
             - name: OSIE_ENCRYPTION_DEFAULT_KEY
               valueFrom:

--- a/charts/osie/values.yaml
+++ b/charts/osie/values.yaml
@@ -78,6 +78,8 @@ api:
   ##     value: "bar"
   ##
   extraEnvVars: []
+  ## @param api.logLevel Specify a custom log level for the API. INFO, DEBUG, ERROR, WARNING or TRACE
+  logLevel: INFO
 
 adminApi:
   oauth2:


### PR DESCRIPTION
* Fixed secret usage for rabbitmq, default to rabbitmq-password if not set, since that's todays hardcoded default.

* Added logLevel value to API