### PR TITLE
Allow overriding self.*-base-url via values for non-ingress exposure

### DIFF
--- a/charts/osie/Chart.yaml
+++ b/charts/osie/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 26.3.1
+version: 26.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/osie/templates/_helpers.tpl
+++ b/charts/osie/templates/_helpers.tpl
@@ -435,7 +435,9 @@ Bcrypt password
 {{- end -}}
 
 {{- define "osie.uiUrl" -}}
-{{- if .Values.global.ingress.enabled -}}
+{{- if .Values.ui.baseUrl -}}
+{{- .Values.ui.baseUrl -}}
+{{- else if .Values.global.ingress.enabled -}}
 {{- printf "%s://%s" (include "osie.httpScheme" .) (.Values.ui.ingress.hostname | default .Values.global.ingress.hostname) -}}
 {{- else -}}
 {{- printf "http://%s:%v" (include "osie.uiServiceFQDN" .) .Values.ui.service.port -}}
@@ -443,7 +445,9 @@ Bcrypt password
 {{- end -}}
 
 {{- define "osie.adminUrl" -}}
-{{- if .Values.global.ingress.enabled -}}
+{{- if .Values.admin.baseUrl -}}
+{{- .Values.admin.baseUrl -}}
+{{- else if .Values.global.ingress.enabled -}}
 {{- printf "%s://%s/osie_admin" (include "osie.httpScheme" .) (.Values.admin.ingress.hostname | default .Values.global.ingress.hostname) -}}
 {{- else -}}
 {{- printf "http://%s:%v/osie_admin" (include "osie.adminServiceFQDN" .) .Values.admin.service.port -}}
@@ -456,7 +460,9 @@ Bcrypt password
 {{- end -}}
 
 {{- define "osie.apiBaseUrl" -}}
-{{- if .Values.global.ingress.enabled -}}
+{{- if .Values.api.baseUrl -}}
+{{- .Values.api.baseUrl -}}
+{{- else if .Values.global.ingress.enabled -}}
 {{- printf "%s://%s" (include "osie.httpScheme" .) (.Values.api.ingress.hostname | default .Values.global.ingress.hostname) -}}
 {{- else -}}
 {{- printf "http://%s:%v" (include "osie.apiServiceFQDN" .) .Values.api.service.port -}}

--- a/charts/osie/templates/osie-api/api-properties-configmap.yaml
+++ b/charts/osie/templates/osie-api/api-properties-configmap.yaml
@@ -21,9 +21,22 @@ data:
       license:
         key: {{ .Values.license.key }}
       self:
-        api-base-url: {{ include "osie.httpScheme" $apiContext }}://{{ include "osie.ingressHostname" $apiContext }}
+        {{- if .Values.global.baseUrl }}
+        base-url: {{ .Values.global.baseUrl }}
+        {{- with .Values.api.baseUrl }}
+        api-base-url: {{ . }}
+        {{- end }}
+        {{- with .Values.ui.baseUrl }}
+        ui-base-url: {{ . }}
+        {{- end }}
+        {{- with .Values.admin.baseUrl }}
+        admin-base-url: {{ . }}
+        {{- end }}
+        {{- else }}
+        api-base-url: {{ include "osie.apiBaseUrl" . }}
         ui-base-url: {{ include "osie.uiUrl" . }}
         admin-base-url: {{ include "osie.adminUrl" . }}
+        {{- end }}
     spring:
       rabbitmq:
         host: {{ include "osie.rabbitmq.host" . }}

--- a/charts/osie/values.yaml
+++ b/charts/osie/values.yaml
@@ -7,6 +7,11 @@ fullnameOverride: ""
 
 global:
   clusterDomain: cluster.local
+  ## @param global.baseUrl Public base URL used when osie is exposed outside the cluster by a non-ingress mechanism (e.g. Gateway API or another CRD).
+  ## When set, the osie-api `self.base-url` property is populated with this value and the per-component
+  ## `self.{api,ui,admin}-base-url` properties are NOT auto-derived from ingress hostnames or in-cluster FQDNs.
+  ## To configure per-component URLs alongside this, set `api.baseUrl`, `ui.baseUrl` and/or `admin.baseUrl` explicitly.
+  baseUrl: ""
   ingress:
     enabled: false
     hostname: ""
@@ -23,6 +28,9 @@ global:
 api:
   component: "api"
   replicaCount: 1
+  ## @param api.baseUrl Public base URL of osie-api. Takes precedence over the ingress hostname and in-cluster FQDN
+  ## when populating `self.api-base-url` in osie-api configuration.
+  baseUrl: ""
   image:
     repository: ghcr.io/osie/osie-api
     pullPolicy: Always
@@ -92,6 +100,9 @@ adminApi:
 ui:
   component: "ui"
   replicaCount: 1
+  ## @param ui.baseUrl Public base URL of osie-ui. Takes precedence over the ingress hostname and in-cluster FQDN
+  ## when populating `self.ui-base-url` in osie-api configuration.
+  baseUrl: ""
   image:
     repository: ghcr.io/osie/osie-ui
     pullPolicy: Always
@@ -146,6 +157,9 @@ ui:
 admin:
   component: "admin"
   replicaCount: 1
+  ## @param admin.baseUrl Public base URL of osie-admin. Takes precedence over the ingress hostname and in-cluster FQDN
+  ## when populating `self.admin-base-url` in osie-api configuration.
+  baseUrl: ""
   image:
     repository: ghcr.io/osie/osie-admin
     pullPolicy: Always


### PR DESCRIPTION
Users that disable the chart-managed ingress and expose osie via their own mechanism (Gateway API, other CRDs) can now set:

- global.baseUrl -> osie.self.base-url
- api.baseUrl -> osie.self.api-base-url
- ui.baseUrl -> osie.self.ui-base-url
- admin.baseUrl -> osie.self.admin-base-url

Resolution for each per-component URL: explicit baseUrl -> ingress hostname -> in-cluster FQDN. When global.baseUrl is set, the per-component URLs are only emitted when their respective baseUrl values are set (no auto-derivation), since the user is now responsible for exposure.