### PR TITLE
Add conditions in variable definitions helper file

### DIFF
--- a/charts/osie/templates/_helpers.tpl
+++ b/charts/osie/templates/_helpers.tpl
@@ -96,7 +96,6 @@ Retrieve key of the MongoDB secret
 {{- end -}}
 {{- end -}}
 
-
 {{/**/}}
 {{/*Retrieve key of the MongoDB secret*/}}
 {{/**/}}
@@ -317,7 +316,6 @@ Retrieve key of bcrypt secret key
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Expand the name of the chart.
 */}}
@@ -434,24 +432,25 @@ Bcrypt password
 {{- printf "%s.%s.svc.%s" (include "osie.componentName" $adminContext) (include "common.names.namespace" .) .Values.global.clusterDomain -}}
 {{- end -}}
 
+
 {{- define "osie.uiUrl" -}}
-{{- if .Values.ui.baseUrl -}}
-{{- .Values.ui.baseUrl -}}
-{{- else if .Values.global.ingress.enabled -}}
-{{- printf "%s://%s" (include "osie.httpScheme" .) (.Values.ui.ingress.hostname | default .Values.global.ingress.hostname) -}}
-{{- else -}}
-{{- printf "http://%s:%v" (include "osie.uiServiceFQDN" .) .Values.ui.service.port -}}
-{{- end -}}
+  {{- if .Values.global.ingress.enabled -}}
+    {{- printf "%s://%s" (include "osie.httpScheme" .) (.Values.ui.ingress.hostname | default .Values.global.ingress.hostname) -}}
+  {{- else if .Values.global.ingress.hostname -}}
+    {{- printf "%s://%s" (include "osie.httpScheme" .) .Values.global.ingress.hostname -}}
+  {{- else -}}
+    {{- printf "http://%s:%v" (include "osie.uiServiceFQDN" .) .Values.ui.service.port -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "osie.adminUrl" -}}
-{{- if .Values.admin.baseUrl -}}
-{{- .Values.admin.baseUrl -}}
-{{- else if .Values.global.ingress.enabled -}}
-{{- printf "%s://%s/osie_admin" (include "osie.httpScheme" .) (.Values.admin.ingress.hostname | default .Values.global.ingress.hostname) -}}
-{{- else -}}
-{{- printf "http://%s:%v/osie_admin" (include "osie.adminServiceFQDN" .) .Values.admin.service.port -}}
-{{- end -}}
+  {{- if .Values.global.ingress.enabled -}}
+    {{- printf "%s://%s/osie_admin" (include "osie.httpScheme" .) (.Values.admin.ingress.hostname | default .Values.global.ingress.hostname) -}}
+  {{- else if .Values.global.ingress.hostname -}}
+    {{- printf "%s://%s/osie_admin" (include "osie.httpScheme" .) .Values.global.ingress.hostname -}}
+  {{- else -}}
+    {{- printf "http://%s:%v/osie_admin" (include "osie.adminServiceFQDN" .) .Values.admin.service.port -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "osie.apiServiceFQDN" -}}
@@ -460,13 +459,13 @@ Bcrypt password
 {{- end -}}
 
 {{- define "osie.apiBaseUrl" -}}
-{{- if .Values.api.baseUrl -}}
-{{- .Values.api.baseUrl -}}
-{{- else if .Values.global.ingress.enabled -}}
-{{- printf "%s://%s" (include "osie.httpScheme" .) (.Values.api.ingress.hostname | default .Values.global.ingress.hostname) -}}
-{{- else -}}
-{{- printf "http://%s:%v" (include "osie.apiServiceFQDN" .) .Values.api.service.port -}}
-{{- end -}}
+  {{- if .Values.global.ingress.enabled -}}
+    {{- printf "%s://%s" (include "osie.httpScheme" .) (.Values.api.ingress.hostname | default .Values.global.ingress.hostname) -}}
+  {{- else if .Values.global.ingress.hostname -}}
+    {{- printf "%s://%s" (include "osie.httpScheme" .) .Values.global.ingress.hostname -}}
+  {{- else -}}
+    {{- printf "http://%s:%v" (include "osie.apiServiceFQDN" .) .Values.api.service.port -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "osie.apiUrl" -}}


### PR DESCRIPTION
To enable cascading variable resolutions to respect values.global.ingress.hostname when ingress.enable is false when using other ingress methods than the supported one. 
Affected values are
self:
  api-base-url: 
  ui-base-url: 
  admin-base-url: 