### PR TITLE
OSIE-470: route /realms to the API ingress; chart 26.3.3

### DIFF
--- a/charts/osie/Chart.yaml
+++ b/charts/osie/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 26.3.2
+version: 26.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/osie/values.yaml
+++ b/charts/osie/values.yaml
@@ -38,6 +38,7 @@ api:
     paths:
       - /api-v1
       - /admin_api/v1
+      - /realms
       - /v3/api-docs
       - /.well-known
     pathType: Prefix


### PR DESCRIPTION
With Keycloak disabled, OSIE itself is the OIDC provider: the admin/ui discover at <base>/realms/<slug>/.well-known/openid-configuration and run oauth2 under /realms/<slug>/*, all served by osie-api. Add /realms to api.ingress.paths so the ingress routes it to the API (previously Keycloak's own host served realm discovery). Patch chart bump 26.3.2 -> 26.3.3.