### PR TITLE
release: osie 26.4.0

### DIFF
--- a/charts/osie/Chart.yaml
+++ b/charts/osie/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 26.3.3
+version: 26.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "26.3.1"
+appVersion: "26.4.0"
 
 dependencies:
   - name: mongodb


### PR DESCRIPTION
## Release 26.4.0

Manual chart bump completing the 26.4.0 release (pipeline Tag & Release blocked by a permanently locked tag name from a past immutable release; git tags shipped as v26.4.0, images/chart stay 26.4.0).

- appVersion: `26.4.0`
- All images validated via E2E tests (run 28702971478)
- Public images available at `ghcr.io/osie/*:26.4.0`

**Merge to publish chart to helm.osie.io**