### PR TITLE
OSIE-477 expose admin OIDC role mapping in api config

### DIFF
--- a/charts/osie/Chart.yaml
+++ b/charts/osie/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 26.4.0
+version: 26.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/osie/templates/osie-api/api-properties-configmap.yaml
+++ b/charts/osie/templates/osie-api/api-properties-configmap.yaml
@@ -54,6 +54,13 @@ data:
         oauth2:
           issuer-uri: {{ $adminIssuerUri }}
           client-id: {{ include "osie.oauth2ClientId" $adminContext | trim }}
+          {{- with .Values.admin.oauth2.rolesClaim }}
+          roles-claim: {{ . }}
+          {{- end }}
+          {{- with .Values.admin.oauth2.roleMappings }}
+          role-mappings:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- else }} {}
         {{- end }}
       admin-api:

--- a/charts/osie/values.yaml
+++ b/charts/osie/values.yaml
@@ -178,6 +178,12 @@ admin:
     scope: "openid profile email offline_access"
     pkce:
       enabled: true
+    ## @param admin.oauth2.rolesClaim JWT claim carrying the IdP-assigned roles (e.g. "roles" or "groups").
+    ## Only used with an external issuer (REMOTE_OIDC).
+    rolesClaim:
+    ## @param admin.oauth2.roleMappings Claim value → admin role name (e.g. osie-admins: SUPER_ADMIN).
+    ## When set, admin access requires a mapped claim value; declaration order decides precedence.
+    roleMappings: { }
   # Keycloak Realm name if enabled
   realm:
     name: "master"


### PR DESCRIPTION
## Summary

- `admin.oauth2.rolesClaim` — JWT claim carrying the IdP-assigned roles (e.g. `roles`, `groups`).
- `admin.oauth2.roleMappings` — claim value → admin role name map (e.g. `osie-admins: SUPER_ADMIN`). When set, admin access requires a mapped claim value; declaration order decides precedence.

Both render into the API's `auth.admin.oauth2` block only when an external admin issuer is configured. Companion to osie-api#94 (REMOTE_OIDC admin role mapping, OSIE-477).

## Testing

`helm template` verified: values render as `roles-claim`/`role-mappings`; output unchanged when the values are unset (both with an external issuer and with the built-in default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148CK7cQfQtBhBSn2b8qh4d